### PR TITLE
[#1] Fix problem with building eclipse-plugin-dev-from-intellij due t…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.withType(KotlinCompile::class.java).all {
   targetCompatibility = javaVersion.name
   
   kotlinOptions {
-    jvmTarget = javaVersion.name
+    jvmTarget = javaVersion.toString()
     apiVersion = kotlinVersion
     languageVersion = kotlinVersion
   }


### PR DESCRIPTION
…o wrong kotlin compiler config

javaVersion.toString() used instead of javaVersion.name